### PR TITLE
Make image as small as possible

### DIFF
--- a/50-default.conf
+++ b/50-default.conf
@@ -1,9 +1,0 @@
-$template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [TOKEN@41058 tag=\"TAG\"] %msg%\n"
-
-*.* @@logs-01.loggly.com:514;LogglyFormat
-
-$ModLoad imudp
-$UDPServerRun 514
-$ModLoad imtcp
-$InputTCPServerRun 514
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,14 @@
 #
 #################################################################
 
-FROM ubuntu:trusty
+FROM alpine:3.2
 MAINTAINER Jonathan Short <jonathan.short@sendgrid.com>
 
-RUN apt-get update
-RUN apt-get -y dist-upgrade
+RUN apk add --update rsyslog && rm -rf /var/cache/apk/*
 
 ADD run.sh /tmp/run.sh
 RUN chmod +x /tmp/run.sh
-ADD 50-default.conf /etc/rsyslog.d/50-default.conf
+ADD rsyslog.conf /etc/
 
 EXPOSE 514
 EXPOSE 514/udp

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,0 +1,17 @@
+# Input modules
+$ModLoad immark.so         # provide --MARK-- message capability
+$ModLoad imuxsock.so       # provide local system logging (e.g. via logger command)
+
+# Output modes
+$ModLoad omstdout.so       # provide messages to stdout
+*.* :omstdout:             # send everything to stdout
+
+$template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [TOKEN@41058 tag=\"TAG\"] %msg%\n"
+
+*.* @@logs-01.loggly.com:514;LogglyFormat
+
+$ModLoad imudp
+$UDPServerRun 514
+$ModLoad imtcp
+$InputTCPServerRun 514
+

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ -z "$TOKEN" ]; then
   echo "Missing \$TOKEN"
@@ -10,8 +10,8 @@ if [ -z "$TAG" ]; then
   exit 1
 fi
 
-sed -i "s/TOKEN/$TOKEN/" /etc/rsyslog.d/50-default.conf
-sed -i "s/TAG/$TAG/" /etc/rsyslog.d/50-default.conf
+sed -i "s/TOKEN/$TOKEN/" /etc/rsyslog.conf
+sed -i "s/TAG/$TAG/" /etc/rsyslog.conf
 
 exec /usr/sbin/rsyslogd -n
 


### PR DESCRIPTION
The following changes are proposed:
- Use Alpine official image instead of Ubuntu; this brings the image down to 7.5MB instead of 236.6MB.
- Use one minimal rsyslog.conf file; this sends only to Loggly and to stdout (still visible in
container logs).
- The shebang for run.sh is also changed to SH because Alpine does not come
with BASH.