### PR TITLE
Use specific environment variables

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -6,7 +6,7 @@ $ModLoad imuxsock.so       # provide local system logging (e.g. via logger comma
 $ModLoad omstdout.so       # provide messages to stdout
 *.* :omstdout:             # send everything to stdout
 
-$template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [TOKEN@41058 tag=\"TAG\"] %msg%\n"
+$template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [LOGGLY_AUTH_TOKEN@41058 tag=\"LOGGLY_TAG\"] %msg%\n"
 
 *.* @@logs-01.loggly.com:514;LogglyFormat
 

--- a/run.sh
+++ b/run.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 
-if [ -z "$TOKEN" ]; then
-  echo "Missing \$TOKEN"
+if [ -z "$LOGGLY_AUTH_TOKEN" ]; then
+  echo "Missing \$LOGGLY_AUTH_TOKEN"
   exit 1
 fi
 
-if [ -z "$TAG" ]; then
-  echo "Missing \$TAG"
+if [ -z "$LOGGLY_TAG" ]; then
+  echo "Missing \$LOGGLY_TAG"
   exit 1
 fi
 
-sed -i "s/TOKEN/$TOKEN/" /etc/rsyslog.conf
-sed -i "s/TAG/$TAG/" /etc/rsyslog.conf
+sed -i "s/LOGGLY_AUTH_TOKEN/$LOGGLY_AUTH_TOKEN/" /etc/rsyslog.conf
+sed -i "s/LOGGLY_TAG/$LOGGLY_TAG/" /etc/rsyslog.conf
 
 exec /usr/sbin/rsyslogd -n
 


### PR DESCRIPTION
I would also like to propose the use of more specific environment variables for token and tag. This helps avoid conflicts with other similar ones.

For example, I use docker-compose, and I keep tokens and other sensitive information in a `.env` file. This is loaded by `env_file` in compose. In the same file I also have CloudFlare and other tokens. This change helps declare all variables in a more consistent manner. There might also be other scenarios for this.

Thanks.

Signed-off-by: Vlad Ghinea <vlad@ghn.me>