### PR TITLE
Add support for multiple tags.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,9 @@ fi
 # Create spool directory
 mkdir -p /var/spool/rsyslog
 
+# Expand multiple tags, in the format of tag1:tag2:tag3, into several tag arguments
+LOGGLY_TAG=$(echo $LOGGLY_TAG | sed 's/:/\\\\" tag=\\\\"/g')
+
 # Replace variables
 sed -i "s/LOGGLY_AUTH_TOKEN/$LOGGLY_AUTH_TOKEN/" /etc/rsyslog.conf
 sed -i "s/LOGGLY_TAG/$LOGGLY_TAG/" /etc/rsyslog.conf


### PR DESCRIPTION
Expand tags in the format of `tag1:tag2:tag3` into separate tags. Addresses #5.