### PR TITLE
Add LOGGLY_DEBUG variable to enable STDOUT logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Docker container for loggly (via rsyslog). Check out Loggly's [Docker logging do
 Usage:
 
 ```
-docker run -e LOGGLY_AUTH_TOKEN=[Loggly Customer Token] -e LOGGLY_TAG=[Tag Describing Source] sendgridlabs/loggly-docker
+docker run -e LOGGLY_AUTH_TOKEN=[Loggly Customer Token] -e LOGGLY_TAG=[Tag Describing Source] LOGGLY_DEBUG=true sendgridlabs/loggly-docker
 ```
 

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -8,8 +8,7 @@ $ModLoad omstdout.so       # provide messages to stdout
 # Loggly template format
 $template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [LOGGLY_AUTH_TOKEN@41058 tag=\"LOGGLY_TAG\"] %msg%\n"
 
-# Send everything to stdout and Loggly
-*.* :omstdout:
+# Send everything to Loggly
 *.* @@logs-01.loggly.com:514;LogglyFormat
 
 # Setup disk assisted queues. An on-disk queue is created for this action.

--- a/run.sh
+++ b/run.sh
@@ -25,8 +25,13 @@ fi
 # Create spool directory
 mkdir -p /var/spool/rsyslog
 
+# If LOGGLY_DEBUG is true, write logs to stdout as well
+if [ "$LOGGLY_DEBUG" = true ]; then
+  sed -i "/\*\.\* @@logs-01\.loggly\.com.*/a \*\.\* \:omstdout\:" /etc/rsyslog.conf
+fi
+
 # Expand multiple tags, in the format of tag1:tag2:tag3, into several tag arguments
-LOGGLY_TAG=$(echo $LOGGLY_TAG | sed 's/:/\\\\" tag=\\\\"/g')
+LOGGLY_TAG=$(echo "$LOGGLY_TAG" | sed 's/:/\\\\" tag=\\\\"/g')
 
 # Replace variables
 sed -i "s/LOGGLY_AUTH_TOKEN/$LOGGLY_AUTH_TOKEN/" /etc/rsyslog.conf


### PR DESCRIPTION
This disables stdout logging by default and adds an optional `LOGGLY_DEBUG` environment variable which, when `true`, turns on stdout logging (FIXES #14).
