### PR TITLE
Use only TLS when sending to Loggly

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -8,9 +8,6 @@ $ModLoad omstdout.so       # provide messages to stdout
 # Loggly template format
 $template LogglyFormat,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msgid% [LOGGLY_AUTH_TOKEN@41058 tag=\"LOGGLY_TAG\"] %msg%\n"
 
-# Send everything to Loggly
-*.* @@logs-01.loggly.com:514;LogglyFormat
-
 # Setup disk assisted queues. An on-disk queue is created for this action.
 # If the remote host is down, messages are spooled to disk and sent when
 # it is up again.
@@ -21,16 +18,20 @@ $ActionQueueSaveOnShutdown on     # save messages to disk on shutdown
 $ActionQueueType LinkedList       # run asynchronously
 $ActionResumeRetryCount -1        # infinite retries if host is down
 
-# TCP + SSL/TLS Syslog Server
-$ModLoad imtcp         # provides TCP syslog reception
-$ActionSendStreamDriver gtls
+#RsyslogGnuTLS
 $DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/loggly.crt
+$ActionSendStreamDriver gtls
+$ActionSendStreamDriverMode 1
 $ActionSendStreamDriverAuthMode x509/name
 $ActionSendStreamDriverPermittedPeer *.loggly.com
-$ActionSendStreamDriverMode 1
+
+# Send everything to Loggly over TLS
+*.* @@logs-01.loggly.com:6514;LogglyFormat
+
+# TCP Syslog Server
+$ModLoad imtcp         # provides TCP syslog reception
 $InputTCPServerRun 514 # start a TCP syslog server at standard port 514
 
 # UDP Syslog Server
 $ModLoad imudp         # provides UDP syslog reception
 $UDPServerRun 514      # start a UDP syslog server at standard port 514
-


### PR DESCRIPTION
TLS config had been previously roughed in, but not actually implemented. This PR enables TLS and ensures all communication with Loggly is encrypted. Changes Loggly port from default 514 to 6514, as per https://www.loggly.com/docs/rsyslog-tls-configuration/

Addresses https://github.com/sendgridlabs/loggly-docker/issues/16