### PR TITLE
 - update base alpine image from 3.2 -> 3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 #
 #################################################################
 
-FROM alpine:3.2
+FROM alpine:3.3
 MAINTAINER Jonathan Short <jonathan.short@sendgrid.com>
 
 RUN apk add --update rsyslog rsyslog-tls && rm -rf /var/cache/apk/*

--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -1,6 +1,8 @@
 # Input modules
 $ModLoad immark.so     # provide --MARK-- message capability
 $ModLoad imuxsock.so   # provide local system logging (e.g. via logger command)
+$ModLoad imudp         # provides UDP syslog reception
+$ModLoad imtcp         # provides TCP syslog reception
 
 # Output modules
 $ModLoad omstdout.so       # provide messages to stdout
@@ -29,9 +31,7 @@ $ActionSendStreamDriverPermittedPeer *.loggly.com
 *.* @@logs-01.loggly.com:6514;LogglyFormat
 
 # TCP Syslog Server
-$ModLoad imtcp         # provides TCP syslog reception
 $InputTCPServerRun 514 # start a TCP syslog server at standard port 514
 
 # UDP Syslog Server
-$ModLoad imudp         # provides UDP syslog reception
 $UDPServerRun 514      # start a UDP syslog server at standard port 514


### PR DESCRIPTION
 - move ModLoad of tcp/udp input to beginning of conf file
 - load udp prior to tcp.  avoids segfault (for unknown reason), but
   verified container now propery accepts both tcp and udp without
   segfault and forwards both to loggly