### PR TITLE
Remove PID file upon startup

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -37,6 +37,8 @@ LOGGLY_TAG=$(echo "$LOGGLY_TAG" | sed 's/:/\\\\" tag=\\\\"/g')
 sed -i "s/LOGGLY_AUTH_TOKEN/$LOGGLY_AUTH_TOKEN/" /etc/rsyslog.conf
 sed -i "s/LOGGLY_TAG/$LOGGLY_TAG/" /etc/rsyslog.conf
 
+rm -f /var/run/rsyslogd.pid
+
 # Run RSyslog daemon
 exec /usr/sbin/rsyslogd -n
 


### PR DESCRIPTION
This is necessary as a Loggly failure could result in a stale PID file remaining, preventing Docker from restarting the container as rsyslogd would error out when seeing the stale PID file.
