### PR TITLE
Update the configuration for rsyslog.conf

### DIFF
--- a/rsyslog.conf
+++ b/rsyslog.conf
@@ -22,13 +22,9 @@ $ActionResumeRetryCount -1        # infinite retries if host is down
 
 #RsyslogGnuTLS
 $DefaultNetstreamDriverCAFile /etc/rsyslog.d/keys/ca.d/loggly.crt
-$ActionSendStreamDriver gtls
-$ActionSendStreamDriverMode 1
-$ActionSendStreamDriverAuthMode x509/name
-$ActionSendStreamDriverPermittedPeer *.loggly.com
 
-# Send everything to Loggly over TLS
-*.* @@logs-01.loggly.com:6514;LogglyFormat
+# Send messages to Loggly over TCP using the template.
+action(type="omfwd" protocol="tcp" target="logs-01.loggly.com" port="6514" template="LogglyFormat" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" StreamDriverPermittedPeers="*.loggly.com")
 
 # TCP Syslog Server
 $InputTCPServerRun 514 # start a TCP syslog server at standard port 514


### PR DESCRIPTION
The rsyslog.conf is using old format < 7.x.  Updated the configuration for as per the doc at https://www.loggly.com/docs/rsyslog-tls-configuration/.  It resolves the issue, https://github.com/sendgridlabs/loggly-docker/issues/25